### PR TITLE
J4 Media Manager errors when the plugin is enabled

### DIFF
--- a/plugins/system/sortbyfield/sortbyfield.php
+++ b/plugins/system/sortbyfield/sortbyfield.php
@@ -102,7 +102,7 @@ PHP;
 	public function onContentBeforeSave(?string $context, $table, $isNew = false, $data = null): bool
 	{
 		// Joomla 4 Media Manager freaks out when the plugin is enabled; skip this plugin if the context is com_media.
-		if(str_contains($context,'com_media')) {
+		if (substr($context, 0, 10) === 'com_media.') {
 			return true;
 		}
 		// Joomla 3 does not pass the data from com_menus. Therefore, we have to fake it.

--- a/plugins/system/sortbyfield/sortbyfield.php
+++ b/plugins/system/sortbyfield/sortbyfield.php
@@ -101,6 +101,10 @@ PHP;
 
 	public function onContentBeforeSave(?string $context, $table, $isNew = false, $data = null): bool
 	{
+		// Joomla 4 Media Manager freaks out when the plugin is enabled; skip this plugin if the context is com_media.
+		if(str_contains($context,'com_media')) {
+			return true;
+		}
 		// Joomla 3 does not pass the data from com_menus. Therefore, we have to fake it.
 		if (is_null($data) && version_compare(JVERSION, '3.999.999', 'le'))
 		{


### PR DESCRIPTION
Probably there's a more elegant solution, but this works.

Currently when the plugin is enabled, uploading a file in com_media (or a custom media field returns an error:  "Cannot use object of type Joomla\CMS\Object\CMSObject as array".

The plugin doesn't make sense in com_media anyway so this skips over it entirely.